### PR TITLE
feat: user-defined functions

### DIFF
--- a/src/cst-definitions.d.ts
+++ b/src/cst-definitions.d.ts
@@ -130,9 +130,11 @@ export interface MacrosExpressionCstNode extends CstNode {
 }
 
 export type MacrosExpressionCstChildren = {
-  MacrosIdentifier: IToken[];
+  Identifier: IToken[];
   OpenParenthesis: IToken[];
   arg?: ExprCstNode[];
+  Comma?: IToken[];
+  args?: ExprCstNode[];
   CloseParenthesis: IToken[];
 };
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -40,13 +40,14 @@ export function parse(expression: string): ParseResult {
 // TODO mention about this library in other Google's CEL repos
 export function evaluate(
   expression: string | CstNode,
-  context?: Record<string, unknown>
+  context?: Record<string, unknown>,
+  functions?: Record<string, CallableFunction>,
 ) {
   const result =
     typeof expression === 'string'
       ? parse(expression)
       : <Success>{ isSuccess: true, cst: expression }
-  const toAstVisitorInstance = new CelVisitor(context)
+  const toAstVisitorInstance = new CelVisitor(context, functions)
 
   if (!result.isSuccess) {
     throw new CelParseError(

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,6 @@ import {
   CloseBracket,
   OpenBracket,
   Comma,
-  MacrosIdentifier,
   OpenCurlyBracket,
   CloseCurlyBracket,
   Colon,
@@ -133,10 +132,14 @@ export class CelParser extends CstParser {
   })
 
   private macrosExpression = this.RULE('macrosExpression', () => {
-    this.CONSUME(MacrosIdentifier)
+    this.CONSUME(Identifier)
     this.CONSUME(OpenParenthesis)
     this.OPTION(() => {
       this.SUBRULE(this.expr, { LABEL: 'arg' })
+      this.MANY(() => {
+        this.CONSUME(Comma)
+        this.SUBRULE2(this.expr, { LABEL: 'args' })
+      })
     })
     this.CONSUME(CloseParenthesis)
   })

--- a/src/spec/macros.spec.ts
+++ b/src/spec/macros.spec.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest'
 
-import { CelTypeError, evaluate } from '..'
+import { CelEvaluationError, CelTypeError, evaluate } from '..'
 import { Operations } from '../helper'
 
 describe('lists expressions', () => {
@@ -81,6 +81,92 @@ describe('lists expressions', () => {
       const result = () => evaluate(expr)
 
       expect(result).toThrow(new CelTypeError(Operations.addition, 123, 123))
+    })
+  })
+})
+
+describe('custom functions', () => {
+  describe('single argument', () => {
+    it('should execute a single argument custom function', () => {
+      const expr = 'foo(bar)'
+
+      const foo = (arg) => {
+        return `foo:${arg}`
+      }
+
+      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+
+      expect(result).toBe("foo:bar")
+    })
+  })
+
+  describe('multi argument', () => {
+    it('should execute a two argument custom function', () => {
+      const expr = 'foo(bar, 42)'
+
+      const foo = (thing, intensity) => {
+        return `foo:${thing} ${intensity}`
+      }
+
+      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+
+      expect(result).toBe("foo:bar 42")
+    })
+
+    it('should execute a three argument custom function', () => {
+      const expr = 'foo(bar, 42, true)'
+
+      const foo = (thing, intensity, enable) => {
+        return `foo:${thing} ${intensity} ${enable}`
+      }
+
+      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+
+      expect(result).toBe("foo:bar 42 true")
+    })
+  })
+
+  describe('interaction with default functions', () => {
+    it('should preserve default functions when custom functions specified', () => {
+      const expr = 'foo(bar, size("ubernete"), true)'
+
+      const foo = (thing, intensity, enable) => {
+        return `foo:${thing} ${intensity} ${enable}`
+      }
+
+      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+
+      expect(result).toBe("foo:bar 8 true")
+    })
+
+    it('should allow overriding default functions', () => {
+      const expr = 'foo(bar, size("ubernete"), true)'
+
+      const foo = (thing, intensity, enable) => {
+        return `foo:${thing} ${intensity} ${enable}`
+      }
+
+      const result = evaluate(expr, {bar: "bar"}, {foo: foo, size: () => "strange"})
+
+      expect(result).toBe("foo:bar strange true")
+    })
+  })
+
+  describe('unknown functions', () => {
+    it('should throw when an unknown function is called', () => {
+      const expr = 'foo(bar)'
+
+      const result = () => evaluate(expr)
+
+      expect(result).toThrow(new CelEvaluationError('Macros foo not recognized'))
+    })
+
+    it('should not treat context values as first-class functions', () => {
+      const expr = 'foo(bar)'
+
+      const result = () => evaluate(expr, {foo: 'foo', bar: 'bar'})
+
+      expect(result).toThrow(new CelEvaluationError('Macros foo not recognized'))
     })
   })
 })

--- a/src/spec/macros.spec.ts
+++ b/src/spec/macros.spec.ts
@@ -90,13 +90,13 @@ describe('custom functions', () => {
     it('should execute a single argument custom function', () => {
       const expr = 'foo(bar)'
 
-      const foo = (arg) => {
+      const foo = (arg: unknown) => {
         return `foo:${arg}`
       }
 
-      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+      const result = evaluate(expr, { bar: 'bar' }, { foo })
 
-      expect(result).toBe("foo:bar")
+      expect(result).toBe('foo:bar')
     })
   })
 
@@ -104,25 +104,13 @@ describe('custom functions', () => {
     it('should execute a two argument custom function', () => {
       const expr = 'foo(bar, 42)'
 
-      const foo = (thing, intensity) => {
+      const foo = (thing: unknown, intensity: unknown) => {
         return `foo:${thing} ${intensity}`
       }
 
-      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+      const result = evaluate(expr, { bar: 'bar' }, { foo })
 
-      expect(result).toBe("foo:bar 42")
-    })
-
-    it('should execute a three argument custom function', () => {
-      const expr = 'foo(bar, 42, true)'
-
-      const foo = (thing, intensity, enable) => {
-        return `foo:${thing} ${intensity} ${enable}`
-      }
-
-      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
-
-      expect(result).toBe("foo:bar 42 true")
+      expect(result).toBe('foo:bar 42')
     })
   })
 
@@ -134,9 +122,9 @@ describe('custom functions', () => {
         return `foo:${thing} ${intensity} ${enable}`
       }
 
-      const result = evaluate(expr, {bar: "bar"}, {foo: foo})
+      const result = evaluate(expr, { bar: 'bar' }, { foo: foo })
 
-      expect(result).toBe("foo:bar 8 true")
+      expect(result).toBe('foo:bar 8 true')
     })
 
     it('should allow overriding default functions', () => {
@@ -146,9 +134,13 @@ describe('custom functions', () => {
         return `foo:${thing} ${intensity} ${enable}`
       }
 
-      const result = evaluate(expr, {bar: "bar"}, {foo: foo, size: () => "strange"})
+      const result = evaluate(
+        expr,
+        { bar: 'bar' },
+        { foo: foo, size: () => 'strange' }
+      )
 
-      expect(result).toBe("foo:bar strange true")
+      expect(result).toBe('foo:bar strange true')
     })
   })
 
@@ -158,15 +150,19 @@ describe('custom functions', () => {
 
       const result = () => evaluate(expr)
 
-      expect(result).toThrow(new CelEvaluationError('Macros foo not recognized'))
+      expect(result).toThrow(
+        new CelEvaluationError('Macros foo not recognized')
+      )
     })
 
     it('should not treat context values as first-class functions', () => {
       const expr = 'foo(bar)'
 
-      const result = () => evaluate(expr, {foo: 'foo', bar: 'bar'})
+      const result = () => evaluate(expr, { foo: 'foo', bar: 'bar' })
 
-      expect(result).toThrow(new CelEvaluationError('Macros foo not recognized'))
+      expect(result).toThrow(
+        new CelEvaluationError('Macros foo not recognized')
+      )
     })
   })
 })

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -202,17 +202,6 @@ export const Minus = createToken({
   categories: [AdditionOperator, UnaryOperator],
 })
 
-export const MacrosIdentifier = createToken({
-  name: 'MacrosIdentifier',
-  pattern: Lexer.NA,
-})
-
-export const Size = createToken({
-  name: 'Size',
-  pattern: /size/,
-  categories: MacrosIdentifier,
-})
-
 export const Identifier = createToken({
   name: 'Identifier',
   pattern: /[a-zA-Z_][a-zA-Z0-9_]*/,
@@ -251,9 +240,6 @@ export const allTokens = [
   GreaterThan,
   LessThan,
   In,
-
-  MacrosIdentifier,
-  Size,
 
   UnaryOperator,
   LogicalNotOperator,


### PR DESCRIPTION
## Describe your changes

This adds support for providing user-defined functions.

The parser is updated to allow any identifier to be a callable macro or function.

A new optional argument to `evaluate` allows registering custom functions.

---

I think I could follow this with support for the missing macros (`exists`, `has`, etc) as well as some of the built-in functions like `matches`.

Thank you!

## Issue ticket number/link

I can open one if you think this needs more discussion there!

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have added tests (if possible)
- [ ] I have updated the readme (if necessary)
- [ ] I have updated the demo (if necessary)
