### PR TITLE
feat: support `has()` macro

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -38,8 +38,16 @@ import { evaluate, parse } from 'cel-js'
   console.log(`${mapExpr} => ${JSON.stringify(evaluate(mapExpr))}`) // => { a: 1, b: 2 }
 
   // Macro expressions
+  // size()
   const macroExpr = 'size([1, 2])'
   console.log(`${macroExpr} => ${evaluate(macroExpr)}`) // => 2
+
+  // has()
+  const hasExpr = 'has(user.role)'
+  console.log(`${hasExpr} => ${evaluate(hasExpr, context)}`) // => true
+  
+  const hasExpr2 = 'has(user.name)'
+  console.log(`${hasExpr2} => ${evaluate(hasExpr2, context)}`) // => false
 
   // Custom function expressions
   const functionExpr = 'max(2, 1, 3, 7)'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cel-js",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Common Expression Language (CEL) evaluator for JavaScript",
   "keywords": [
     "Common Expression Language",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -327,3 +327,17 @@ export const size = (arr: unknown) => {
 
   throw new CelEvaluationError(`invalid_argument: ${arr}`)
 }
+
+/**
+ * Macro definition for the CEL has() function that checks if a path exists in an object.
+ * 
+ * @param path - The path to check for existence
+ * @returns boolean - True if the path exists (is not undefined), false otherwise
+ * 
+ * @example
+ * has(obj.field) // returns true if field exists on obj
+ */
+export const has = (path: unknown): boolean => {
+  // If the path itself is undefined, it means the field/index doesn't exist
+  return !(path === undefined)
+}

--- a/src/spec/macros.spec.ts
+++ b/src/spec/macros.spec.ts
@@ -4,6 +4,95 @@ import { CelEvaluationError, CelTypeError, evaluate } from '..'
 import { Operations } from '../helper'
 
 describe('lists expressions', () => {
+  
+  describe('has', () => {
+    it('should return true when nested property exists', () => {
+      const expr = 'has(object.property)'
+
+      const result = evaluate(expr, { object: { property: true } })
+
+      expect(result).toBe(true)
+    })
+
+    it('should return false when property does not exists', () => {
+      const expr = 'has(object.nonExisting)'
+
+      const result = evaluate(expr, { object: { property: true } })
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false when property does not exists, combined with property usage', () => {
+      const expr = 'has(object.nonExisting) && object.nonExisting'
+
+      const result = evaluate(expr, { object: { property: true } })
+
+      expect(result).toBe(false)
+    })
+
+    it('should throw when no arguments are passed', () => {
+      const expr = 'has()'
+      const context = { object: { property: true } }
+
+      expect(() => evaluate(expr, context))
+        .toThrow('has() requires exactly one argument')
+    })
+
+    it('should throw when argument is not an object', () => {
+      const context = { object: { property: true } }
+      const errorMessages = 'has() requires a field selection';
+
+      expect(() => evaluate('has(object)', context))
+        .toThrow(errorMessages)
+    
+      expect(() => evaluate('has(object[0])', context))
+        .toThrow(errorMessages)
+        
+      expect(() => evaluate('has(object[property])', context))
+        .toThrow(errorMessages)  
+    })
+
+    describe('should throw when argument is an atomic expresion of type', () => {
+      const errorMessages = 'has() does not support atomic expressions'
+      const context = { object: { property: true } }
+
+      it('string', () => {
+        expect(() => evaluate('has("")', context))
+          .toThrow(errorMessages)
+
+        expect(() => evaluate('has("string")', context))
+          .toThrow(errorMessages)
+      })
+
+      it('array', () => {
+        expect(() => evaluate('has([])', context))
+          .toThrow(errorMessages)
+
+        expect(() => evaluate('has([1, 2, 3])', context))
+          .toThrow(errorMessages)
+      })
+
+      it('boolean', () => {
+        expect(() => evaluate('has(true)', context))
+          .toThrow(errorMessages)
+
+        expect(() => evaluate('has(false)', context))
+          .toThrow(errorMessages)
+      })
+
+      it('number', () => {
+        expect(() => evaluate('has(42)', context))
+          .toThrow(errorMessages)
+
+        expect(() => evaluate('has(0)', context))
+          .toThrow(errorMessages)
+
+        expect(() => evaluate('has(0.3)', context))
+          .toThrow(errorMessages)
+      })
+    })    
+  })
+
   describe('size', () => {
     describe('list', () => {
       it('should return 0 for empty list', () => {


### PR DESCRIPTION
## Describe your changes
I'm adding support for the `has()` macro. I'm providing it similarly to the existing `size()` macro. I did copy the [GO style of the macro](https://github.com/google/cel-go?tab=readme-ov-file#macros) `has(object.property)` to maximise interoperability. 

A big part of supporting `has()` is done in a few different visitors:

1. **`macrosExpression`** supports `has()` as a special case and calls for a helper method to handle it. For any other macro, the process continues to work the same.
2. **`handleHasMacro`** — handles the `has()` case, trying to evaluate the argument provided to the macro. The method will throw if no arguments are passed. The method also sets up an `inHas` context, which visitors later use to change the default behaviour if called in a `has()` macro—The context approach mimics GO implementation. I'm not a GO developer, so I did my best to understand how they deal with this. The method will rethrow any exceptions thrown by called visitors; this is how we deal with invalid arguments.
3. **`conditionalAnd`** — I've added a short circuit for cases where the left side operand is false. This allows to use has as a check for existence:
```cel
has(object.nonExisting) && object.nonExisting
```
4. **`atomicExpression`** — Will throw when called in the `in` context and evaluate an `identifierExpression`.
5. **`identifierExpression`** — This is the only allowed case for a `has()` macro. It still will throw if not called for an `identifierDotExpression` context.

### Expected success cases
```typescript
const context = { object: { property: true } }

evaluate('has(object.property)', context) // true
evaluate('has(object.nonExisting)', context) // false
evaluate('has(object.nonExisting) && object.nonExisting', context) // false
```

### Expected errors

```typescript
const context = { object: { property: true } }

evaluate('has()', context)
evaluate('has(object)', context)
evaluate('has(1)', context)
evaluate('has("string")', context)
evaluate('has([])', context)
evaluate('has([1,2,3])', context)
evaluate('has(object[0])', context)
```

### Disclaimer 

I used the AWS Q AI assistant while working on the implementation and documentation. I reviewed the proposed code.

## Issue ticket number/link
https://github.com/ChromeGG/cel-js/issues/32


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [X] I have added tests (if possible)
- [ ] I have updated the readme (if necessary)
- [ ] I have updated the demo (if necessary)
