### PR TITLE
fix: update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "outDir": "./dist",
     "baseUrl": "./src",


### PR DESCRIPTION
The source map files will be outputted in the dist directory, while the src directory will not be published. So a warn message will be logged to the terminal: `Sourcemap for "xxx/node_modules/.pnpm/cel-js@0.3.0/node_modules/cel-js/dist/errors/CelParseError.js" points to missing source files`

<img width="848" alt="image" src="https://github.com/user-attachments/assets/f81e3a33-888b-4992-a933-b03b6b686d11" />


## Describe your changes

`sourceMap`: true -> false


## Issue ticket number/link



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added tests (if possible)
- [ ] I have updated the readme (if necessary)
- [ ] I have updated the demo (if necessary)
