### PR TITLE
feat: single-quoted string literals (#53)

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -21,7 +21,7 @@ import { evaluate, parse } from 'cel-js'
   console.log(`${booleanExpr} => ${evaluate(booleanExpr)}`) // => true
 
   // String concatenation
-  const stringExpr = '"foo" + "bar"'
+  const stringExpr = `"foo" + 'bar'`
   console.log(`${stringExpr} => ${evaluate(stringExpr)}`) // => 'foobar'
 
   // Identifier expression with context

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,11 @@ Try out `cel-js` in your browser with the [live demo](https://stackblitz.com/git
     - [x] double
     - [x] bool
     - [x] string
+      - [x] single-quote string
+      - [x] double-quote string
+      - [ ] raw string
+      - [ ] triple-quote string
+      - [ ] byte string
     - [x] hexadecimal
     - [ ] bytes
     - [x] list

--- a/src/spec/atomic-expression.spec.ts
+++ b/src/spec/atomic-expression.spec.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it } from 'vitest'
 
 import { evaluate } from '..'
+import { CelParseError } from '../errors/CelParseError'
 
 describe('atomic expressions', () => {
   it('should evaluate a number', () => {
@@ -43,12 +44,46 @@ describe('atomic expressions', () => {
     expect(result).toBeNull()
   })
 
-  it('should evaluate a string literal', () => {
+  it('should evaluate a double-quoted string literal', () => {
     const expr = '"foo"'
 
     const result = evaluate(expr)
 
     expect(result).toBe('foo')
+  })
+
+  it('should evaluate a single-quoted string literal', () => {
+    const expr = "'foo'"
+
+    const result = evaluate(expr)
+
+    expect(result).toBe('foo')
+  })
+
+  it('should not parse a double-quoted string with a newline', () => {
+    const expr = `"fo
+o"`
+
+    const result = () => evaluate(expr)
+
+    expect(result).toThrow(
+      new CelParseError(
+        'Given string is not a valid CEL expression: Redundant input, expecting EOF but found: o',
+      ),
+    )
+  })
+
+  it('should not parse a single-quoted string with a newline', () => {
+    const expr = `'fo
+o'`
+
+    const result = () => evaluate(expr)
+
+    expect(result).toThrow(
+      new CelParseError(
+        'Given string is not a valid CEL expression: Redundant input, expecting EOF but found: o',
+      ),
+    )
   })
 
   it('should evaluate a float', () => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -90,7 +90,7 @@ export const Null = createToken({ name: 'Null', pattern: /null/ })
 
 export const StringLiteral = createToken({
   name: 'StringLiteral',
-  pattern: /"(?:[^"\\]|\\.)*"/,
+  pattern: /(?:"(?:[^"\n\\]|\\.)*")|(?:'(?:[^'\n\\]|\\.)*')/,
 })
 
 export const reservedIdentifiers = [


### PR DESCRIPTION
## Describe your changes

Extend the regular expression for string literals to also accept single quotes as delimiters. Additionally update the regex to disallow newlines within string literals.

I didn't go any further than single-quote support, since I suppose handling the escape sequences and other string behavior might require moving beyond a regex. 

## Issue ticket number/link

https://github.com/ChromeGG/cel-js/issues/53

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added tests (if possible)
- [x] I have updated the readme (if necessary)
- [ ] I have updated the demo (if necessary)
